### PR TITLE
Fix tests

### DIFF
--- a/src/iconv.jl
+++ b/src/iconv.jl
@@ -25,7 +25,7 @@ function iconv_open(tocode, fromcode)
     elseif errno() == EINVAL
         error("conversion from $fromcode to $tocode not supported by iconv implementation, check that specified encodings are correct")
     else
-       error("iconv_open error $(errno()): $(strerror(errno()))")
+        error("iconv_open error $(errno()): $(strerror(errno()))")
     end
 end
 
@@ -248,7 +248,7 @@ end
 ## Functions to encode/decode strings
 
 encoding_string(::Type{ASCIIString}) = "ASCII"
-encoding_string(::Type{UTF8String}) = "UTF-8"
+encoding_string(::Type{UTF8String})  = "UTF-8"
 encoding_string(::Type{UTF16String}) = (ENDIAN_BOM == 0x04030201) ? "UTF-16LE" : "UTF-16BE"
 encoding_string(::Type{UTF32String}) = (ENDIAN_BOM == 0x04030201) ? "UTF-32LE" : "UTF-32BE"
 

--- a/src/iconv.jl
+++ b/src/iconv.jl
@@ -241,8 +241,8 @@ end
 
 encoding_string(::Type{ASCIIString}) = "ASCII"
 encoding_string(::Type{UTF8String}) = "UTF-8"
-encoding_string(::Type{UTF16String}) = "UTF-16LE"
-encoding_string(::Type{UTF32String}) = "UTF-32LE"
+encoding_string(::Type{UTF16String}) = (ENDIAN_BOM == 0x04030201) ? "UTF-16LE" : "UTF-16BE"
+encoding_string(::Type{UTF32String}) = (ENDIAN_BOM == 0x04030201) ? "UTF-32LE" : "UTF-32BE"
 
 """
     decode(a::Vector{UInt8}, enc::ASCIIString)

--- a/src/iconv.jl
+++ b/src/iconv.jl
@@ -79,7 +79,7 @@ function iconv!(cd::Ptr{Void}, inbuf::Vector{UInt8}, outbuf::Vector{UInt8},
                 (Ptr{Void}, Ptr{Ptr{UInt8}}, Ref{Csize_t}, Ptr{Ptr{UInt8}}, Ref{Csize_t}),
                 cd, inbufptr, inbytesleft, outbufptr, outbytesleft)
 
-    if ret == reinterpret(Csize_t, -1)
+    if ret == -1 % Csize_t
         err = errno()
 
         # Should never happen unless a very small buffer is used
@@ -111,7 +111,7 @@ function iconv_reset!(s::Union{StringEncoder, StringDecoder})
                 (Ptr{Void}, Ptr{Ptr{UInt8}}, Ref{Csize_t}, Ptr{Ptr{UInt8}}, Ref{Csize_t}),
                 s.cd, C_NULL, C_NULL, s.outbufptr, s.outbytesleft)
 
-    if ret == reinterpret(Csize_t, -1)
+    if ret == -1 % Csize_t
         err = errno()
         if err == EINVAL
             error("iconv error: incomplete byte sequence at end of input")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,8 +14,10 @@ for s in ("", "a", "café crème",
 end
 
 # Test a few non-Unicode encodings
-for (s, enc) in (("noël", "ISO-8859-1"), ("noël €", "ISO-8859-15", "CP1252"),
-                   ("Код Обмена Информацией, 8 бит", "KOI8-R"), ("国家标准", "GB18030"))
+for (s, enc) in (("noël", "ISO-8859-1"),
+                 ("noël €", "ISO-8859-15", "CP1252"),
+                 ("Код Обмена Информацией, 8 бит", "KOI8-R"),
+                 ("国家标准", "GB18030"))
     @test decode(encode(s, enc), enc) == s
 end
 
@@ -76,3 +78,5 @@ end
 
 @test_throws ErrorException p = StringEncoder(IOBuffer(), "nonexistent_encoding")
 @test_throws ErrorException p = StringDecoder(IOBuffer(), "nonexistent_encoding")
+
+nothing


### PR DESCRIPTION
Add other invalid error sequence number
Make UTF-16/32 endian specific because default is incorrect on OS X