### PR TITLE
Use StringError exception and errors

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,4 +106,23 @@ end
 @test_throws InvalidEncodingError p = StringEncoder(IOBuffer(), "nonexistent_encoding")
 @test_throws InvalidEncodingError p = StringDecoder(IOBuffer(), "nonexistent_encoding")
 
+try
+    p = StringEncoder(IOBuffer(), "nonexistent_encoding")
+catch err
+    @test isa(err, InvalidEncodingError)
+    io = IOBuffer()
+    showerror(io, err)
+    @test takebuf_string(io) ==
+        "Conversion from UTF-8 to nonexistent_encoding not supported by iconv implementation, check that specified encodings are correct"
+end
+try
+    p = StringDecoder(IOBuffer(), "nonexistent_encoding")
+catch err
+    @test isa(err, InvalidEncodingError)
+    io = IOBuffer()
+    showerror(io, err)
+    @test takebuf_string(io) ==
+        "Conversion from nonexistent_encoding to UTF-8 not supported by iconv implementation, check that specified encodings are correct"
+end
+
 nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,11 +29,23 @@ end
 let s = "a string チャネルパートナーの選択"
     p = StringEncoder(IOBuffer(), "UTF-16LE")
     write(p, s.data[1:10])
-    @test_throws ErrorException close(p)
+    @test_throws IncompleteSequenceError close(p)
+
+    # This time, call show
+    p = StringEncoder(IOBuffer(), "UTF-16LE")
+    write(p, s.data[1:10])
+    try
+        close(p)
+    catch err
+        @test isa(err, IncompleteSequenceError)
+        io = IOBuffer()
+        showerror(io, err)
+        @test takebuf_string(io) == "Incomplete byte sequence at end of input"
+    end
 
     p = StringDecoder(IOBuffer(encode(s, "UTF-16LE")[1:19]), "UTF-16LE")
     @test readall(p) == s[1:9]
-    @test_throws ErrorException close(p)
+    @test_throws IncompleteSequenceError close(p)
 
     # Test stateful encoding, which output some bytes on final reset
     # with strings containing different scripts
@@ -48,39 +60,39 @@ let s = "a string チャネルパートナーの選択"
     close(p)
 end
 
-@test_throws ErrorException encode("qwertyé€", "ASCII")
+@test_throws InvalidSequenceError encode("qwertyé€", "ASCII")
 try
     encode("qwertyé€", "ASCII")
 catch err
      io = IOBuffer()
      showerror(io, err)
      @test takebuf_string(io) ==
-        "iconv error: byte sequence 0xc3a9e282ac is invalid in source encoding or cannot be represented in target encoding"
+        "Byte sequence 0xc3a9e282ac is invalid in source encoding or cannot be represented in target encoding"
 end
 
 # win_iconv currently does not throw an error on bytes >= 0x80 in ASCII sources
 # https://github.com/win-iconv/win-iconv/pull/26
 if OS_NAME != :Windows
-    @test_throws ErrorException decode(b"qwertyé€", "ASCII")
+    @test_throws InvalidSequenceError decode(b"qwertyé€", "ASCII")
     try
         decode(b"qwertyé€", "ASCII")
     catch err
          io = IOBuffer()
          showerror(io, err)
          @test takebuf_string(io) ==
-             "iconv error: byte sequence 0xc3a9e282ac is invalid in source encoding or cannot be represented in target encoding"
+             "Byte sequence 0xc3a9e282ac is invalid in source encoding or cannot be represented in target encoding"
     end
 end
 
 let x = encode("ÄÆä", "ISO-8859-1")
-    @test_throws ErrorException decode(x, "UTF-8")
+    @test_throws InvalidSequenceError decode(x, "UTF-8")
     try
         decode(x, "UTF-8")
     catch err
          io = IOBuffer()
          showerror(io, err)
          @test takebuf_string(io) ==
-             "iconv error: byte sequence 0xc4c6e4 is invalid in source encoding or cannot be represented in target encoding"
+             "Byte sequence 0xc4c6e4 is invalid in source encoding or cannot be represented in target encoding"
     end
 end
 
@@ -91,7 +103,7 @@ mktemp() do p, io
     @test readall(p, "CP1252") == s
 end
 
-@test_throws ErrorException p = StringEncoder(IOBuffer(), "nonexistent_encoding")
-@test_throws ErrorException p = StringDecoder(IOBuffer(), "nonexistent_encoding")
+@test_throws InvalidEncodingError p = StringEncoder(IOBuffer(), "nonexistent_encoding")
+@test_throws InvalidEncodingError p = StringDecoder(IOBuffer(), "nonexistent_encoding")
 
 nothing


### PR DESCRIPTION
This is intended to make error handling a bit cleaner, and also to potentially improve performance in functions where before it would have had to create a GC frame (because of creating a string to pass to error()).